### PR TITLE
Added example github dashboard widget

### DIFF
--- a/sprint/dashboard/views.py
+++ b/sprint/dashboard/views.py
@@ -1,11 +1,46 @@
+from collections import namedtuple
+
 from flask import Blueprint, render_template
+
+from github3 import gh
 
 dash = Blueprint('dashboard',
                  __name__,
                  template_folder='../templates/dashboard')
 
 
+def parse_info(json_data):
+    """
+    Takes the
+    :param json_data:
+    :return:
+    """
+    return json_data['_json_data']
+
+
+def make_example_data():
+    Repository = namedtuple('Repository', 'author name')
+
+    repos = [
+        Repository(author='m1yag1',
+                   name='simple-flask-heroku'),
+        Repository(author='m1yag1',
+                   name='ox-sprint'),
+        Repository(author='openstax',
+                   name='biglearn-sparfa-server')
+    ]
+
+    example_data = []
+
+    for r in repos:
+        repository = gh.repository(r.author, r.name)
+        example_data.append(repository)
+
+    return example_data
+
+
 @dash.route('/', methods=['GET'])
 def dashboard():
-    return render_template('dashboard.html')
+    dash_data = make_example_data()
 
+    return render_template('dashboard.html', data=dash_data)

--- a/sprint/templates/dashboard/dashboard.html
+++ b/sprint/templates/dashboard/dashboard.html
@@ -1,1 +1,32 @@
 {% extends 'layouts/base.html' %}
+
+{% block content %}
+
+  <div class="container">
+    <div class="row">
+      <div class="col s6">
+        <div class="card-panel">
+          <span class="card-title">Example GitHub</span>
+
+          <div class="collection">
+            {% for r in data %}
+            <a href="https://github.com/{{ r.full_name }}" class="collection-item"><span class="badge">{{ r.open_issues }}</span>{{ r.full_name }}</a>
+            {% endfor %}
+          </div>
+        </div>
+      </div>
+
+      <div class="col s6">
+        <div class="card-panel">
+          <span class="card-title">GitHub</span>
+          <div>
+          <button class="btn">Add</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+
+
+{% endblock content %}

--- a/sprint/templates/includes/nav.html
+++ b/sprint/templates/includes/nav.html
@@ -1,0 +1,10 @@
+<div class="navbar-fixed">
+    <nav>
+      <div class="nav-wrapper grey darken-3">
+        <a href="#!" class="brand-logo">ox-sprint</a>
+        <ul class="right hide-on-med-and-down">
+          <li><a href="#">About</a></li>
+        </ul>
+      </div>
+    </nav>
+</div>

--- a/sprint/templates/layouts/base.html
+++ b/sprint/templates/layouts/base.html
@@ -9,6 +9,8 @@
                 {%- block metas %}
                     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
                     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
                 {%- endblock metas %}
 
                 {%- block styles %}
@@ -16,8 +18,12 @@
 
                     <!-- Import Google Icon Font -->
                     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-
+                    <!-- Import Google Roboto Font -->
+                    <link href='http://fonts.googleapis.com/css?family=Roboto:400,100,300,500,700,900' rel='stylesheet'>
                     <!-- Import Custom CSS -->
+                    <!-- Call super() on the child template to run these -->
+                    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.1/css/materialize.min.css">
+
 
                 {%- endblock styles %}
 
@@ -32,6 +38,7 @@
             {% endblock header %}
 
             {% block navbar %}
+              {% include 'includes/nav.html' %}
             {% endblock navbar %}
 
             {% block sidebar %}
@@ -53,6 +60,11 @@
                     <p>
                 </noscript>
                 <!-- ADD JAVASCRIPT SOURCES NEEDED FOR ALL TEMPLATES -->
+
+                <!-- Import jquery before materialize.js -->
+                <script type="text/javascript" src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+
+                <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.1/js/materialize.min.js"></script>
 
             {% endblock scripts %}
 


### PR DESCRIPTION
- Updated the base.html template to use materializecss and the CDN for
simplicity.
- Created a dashboard.html template that is a mock up of how dashboard
widets may look.
- Added a nav bar and template with a respective `includes` folder.
- Created a make_example_data helper to use mock data.